### PR TITLE
Improved separation of concerns for `SfsOpts`

### DIFF
--- a/cmd/suffuse/main.go
+++ b/cmd/suffuse/main.go
@@ -1,11 +1,18 @@
 package main
 
-import . "github.com/suffuse/go-suffuse/suffuse"
+import (
+  . "github.com/suffuse/go-suffuse/suffuse"
+  "os"
+)
 
 func main() {
-  opts := ParseSfsOpts()
+  opts, opts_err := ParseSfsOpts(os.Args)
+  if opts_err != nil {
+    opts_err.PrintUsage()
+    os.Exit(2)
+  }
 
-  mfs, err := opts.Create()
+  mfs, err := NewSfs(opts)
   MaybePanic(err)
 
   err = mfs.Serve()

--- a/suffuse/opts.go
+++ b/suffuse/opts.go
@@ -2,86 +2,109 @@ package suffuse
 
 import (
   "flag"
-  "os"
-  "bazil.org/fuse"
 )
 
 type SfsOpts struct {
   Config, Mountpoint, ExcludeRegex, VolName string
   Scratch, Verbose, Debug bool
-  Args []string
+  Paths []string
+
+  // stored here because it contains references to arguments used to create SfsOpts
+  usage func()
+
+  // stored here so we can generate potential errors during construction
+  mountpointPath Path
 }
 
-func UsageAndExit() {
-  flag.Usage()
-  os.Exit(2)
+func ParseSfsOpts(args []string) (*SfsOpts, *SfsOptsError) {
+
+  opts, err := optsFromArgs(args)
+  if err != nil { return nil, err }
+
+  err = addMountpointPath(opts)
+  if err != nil { return nil, err }
+
+  err = validate(opts)
+
+  return opts, err
 }
 
-func (opts SfsOpts) Create() (Sfs, error) {
-  SetLogLevel(opts.GetLogLevel())
-         mnt := opts.GetMountpoint()
-  mount_opts := []fuse.MountOption { fuse.FSName("suffuse") }
+func (opts *SfsOpts) GetMountpoint() Path { return opts.mountpointPath }
 
-  mount_opts = append(mount_opts, PlatformOptions()...)
-  if opts.VolName != "" {
-    mount_opts = append(mount_opts,
-      fuse.LocalVolume(),
-      fuse.VolumeName(opts.VolName),
-    )
-  }
-  if opts.Config != "" {
-    configFileOpts := ReadJsonFile(NewPath(opts.Config))
-    Echoerr("%v", configFileOpts)
+func optsFromArgs(args []string) (*SfsOpts, *SfsOptsError) {
+  fs := flag.NewFlagSet("suffuse", flag.ContinueOnError)
+
+  fs.Usage = func () {
+    Echoerr("Usage: %s <options> [path path ...]\n", args[0])
+    fs.PrintDefaults()
   }
 
-  c, err := fuse.Mount(mnt.Path, mount_opts...)
-  if err != nil { return Sfs{}, err }
+  opts := &SfsOpts{}
+  opts.usage = fs.Usage
 
+  // fs.StringVar(&opts.Config, "c", "", "suffuse config file")
+  // fs.StringVar(&opts.ExcludeRegex, "x", "", "name exclusion regex")
+  fs.StringVar(&opts.Mountpoint, "m", "", "mount point")
+  fs.StringVar(&opts.VolName, "n", "", "volume name (OSX only)")
+  fs.BoolVar(&opts.Scratch, "t", false, "create scratch directory as mount point")
+  fs.BoolVar(&opts.Verbose, "v", false, "log at INFO level")
+  fs.BoolVar(&opts.Debug, "d", false, "log at DEBUG level")
+
+  err := fs.Parse(args[1:])
+  if err != nil {
+    // Parse has already printed the problem and usage, there is no way to tell it not to do that
+    return nil, &SfsOptsError{err: err.Error(), usage: nil}
+  }
+
+  opts.Paths = fs.Args()
+  return opts, nil
+}
+
+func validate(opts *SfsOpts) *SfsOptsError {
   // Exactly one incoming path for the moment.
   // Eventually more than one could mean a union mount.
-  if len(opts.Args) != 1 { UsageAndExit() }
+  if len(opts.Paths) != 1 { return opts.newError("Suffuse currently accepts a single path") }
 
-  mfs := Sfs {
-    Mountpoint : mnt,
-    RootNode   : NewIdNode(NewPath(opts.Args[0])),
-    Connection : c,
+  mnt := opts.mountpointPath
+  if (!mnt.FileExists()) { return opts.newError(Sprintf("Mountpoint '%s' does not exist", mnt)) }
+
+  for _, path := range opts.Paths {
+    if (!NewPath(path).FileExists()) { return opts.newError(Sprintf("Path '%s' does not exist", path)) }
   }
 
-  /** Start a goroutine which looks for INT/TERM and
-   *  calls unmount on the filesystem. Otherwise ctrl-C
-   *  leaves us with ghost mounts which outlive the process.
-   */
-  trap := func (sig os.Signal) {
-    Echoerr("Caught %s - forcing unmount(2) of %s\n", sig, mfs.Mountpoint)
-    mfs.Unmount()
-  }
-  TrapExit(trap)
-  return mfs, nil
+  return nil
 }
 
-func (opts SfsOpts) GetMountpoint() Path {
-  switch {
-    case opts.Scratch          : return ScratchDir()
-    case opts.Mountpoint != "" : return NewPath(opts.Mountpoint)
-    default                    : UsageAndExit() ; return Path{}
-  }
+func (opts *SfsOpts) newError(msg string) *SfsOptsError {
+  return &SfsOptsError{msg, opts.usage}
 }
 
-func ParseSfsOpts() SfsOpts {
-  opts := SfsOpts{}
+func addMountpointPath(opts *SfsOpts) *SfsOptsError {
 
-  // flag.StringVar(&opts.Config, "c", "", "suffuse config file")
-  // flag.StringVar(&opts.ExcludeRegex, "x", "", "name exclusion regex")
-  flag.StringVar(&opts.Mountpoint, "m", "", "mount point")
-  flag.StringVar(&opts.VolName, "n", "", "volume name (OSX only)")
-  flag.BoolVar(&opts.Scratch, "t", false, "create scratch directory as mount point")
-  flag.BoolVar(&opts.Verbose, "v", false, "log at INFO level")
-  flag.BoolVar(&opts.Debug, "d", false, "log at DEBUG level")
-  flag.Usage = func () {
-    Echoerr("Usage: %s <options> [path path ...]\n", os.Args[0])
-    flag.PrintDefaults()
+  determineMountPoint := func() (Path, *SfsOptsError) {
+    switch {
+      case opts.Scratch          : return ScratchDir(), nil
+      case opts.Mountpoint != "" : return NewPath(opts.Mountpoint), nil
+      default                    : return Path{}, opts.newError("Mountpoint can not be empty if the scratch flag is false")
+    }
   }
-  flag.Parse()
-  opts.Args = flag.Args()
-  return opts
+
+  path, err := determineMountPoint()
+
+  opts.mountpointPath = path
+
+  return err
+}
+
+type SfsOptsError struct {
+  err string
+  usage func()
+}
+
+func (e *SfsOptsError) Error() string { return e.err }
+func (e *SfsOptsError) PrintUsage()   {
+  if e.usage != nil {
+    Echoerr("%s\n", e.err)
+    e.usage()
+  }
 }

--- a/suffuse/path.go
+++ b/suffuse/path.go
@@ -183,3 +183,9 @@ func (x Path) WalkCollect(f func(string, os.FileInfo) string) Lines {
   )
   return NewLines(res...)
 }
+
+// https://github.com/golang/go/issues/1312
+func (x Path) FileExists() bool {
+  _, err := x.OsStat()
+  return err == nil
+}

--- a/suffuse/setup_test.go
+++ b/suffuse/setup_test.go
@@ -1,7 +1,6 @@
 package suffuse
 
 import (
-  "os"
   "testing"
   "strings"
   "runtime"
@@ -46,12 +45,10 @@ seq 1 10000 > bigfile.txt
 }
 
 func startFuse(args ...string) {
-  saved := os.Args
-  os.Args = args
-  opts := ParseSfsOpts()
-  os.Args = saved
+  opts, opts_err := ParseSfsOpts(args)
+  if opts_err != nil { return }
 
-  mfs, err := opts.Create()
+  mfs, err := NewSfs(opts)
   MaybePanic(err)
 
   go func() {

--- a/suffuse/sfs.go
+++ b/suffuse/sfs.go
@@ -4,6 +4,7 @@ import (
   "golang.org/x/net/context"
   "bazil.org/fuse/fs"
   "bazil.org/fuse"
+  "os"
 )
 
 /** Sfs == Suffuse File System.
@@ -25,6 +26,50 @@ type Sfs struct {
 // call fs.Serve to serve the FUSE protocol using an implementation of
 // the service methods in the interfaces FS* (file system), Node* (file
 // or directory), and Handle* (opened file or directory).
+
+func NewSfs(opts *SfsOpts) (*Sfs, error) {
+  SetLogLevel(opts.GetLogLevel())
+         mnt := opts.GetMountpoint()
+  mount_opts := getFuseMountOptions(opts)
+
+  if opts.Config != "" {
+    configFileOpts := ReadJsonFile(NewPath(opts.Config))
+    Echoerr("%v", configFileOpts)
+  }
+
+  c, err := fuse.Mount(mnt.Path, mount_opts...)
+  if err != nil { return nil, err }
+
+  mfs := &Sfs {
+    Mountpoint : mnt,
+    RootNode   : NewIdNode(NewPath(opts.Paths[0])),
+    Connection : c,
+  }
+
+  /** Start a goroutine which looks for INT/TERM and
+   *  calls unmount on the filesystem. Otherwise ctrl-C
+   *  leaves us with ghost mounts which outlive the process.
+   */
+  trap := func (sig os.Signal) {
+    Echoerr("Caught %s - forcing unmount(2) of %s\n", sig, mfs.Mountpoint)
+    mfs.Unmount()
+  }
+  TrapExit(trap)
+  return mfs, nil
+}
+
+func getFuseMountOptions(opts *SfsOpts) []fuse.MountOption {
+  mount_opts := []fuse.MountOption { fuse.FSName("suffuse") }
+  mount_opts = append(mount_opts, PlatformOptions()...)
+  if opts.VolName != "" {
+    mount_opts = append(mount_opts,
+      fuse.LocalVolume(),
+      fuse.VolumeName(opts.VolName),
+    )
+  }
+  return mount_opts
+}
+
 func (u *Sfs) Root() (fs.Node, error) { return u.RootNode, nil }
 
 func (u *Sfs) Init(ctx context.Context, req *fuse.InitRequest, resp *fuse.InitResponse) error {


### PR DESCRIPTION
- Moved the responsibility of reporting errors outside of `SfsOpts`
- Renamed `Args` to `Paths` which reflects intention a bit better
- `ParseSfsOpts` now takes an array of strings and returns (potentially) an error
- Improved general error reporting for the creation of options (options are validated)
- Moved the creation of a `Sfs` to `sfs.go`
- Added a `FileExists` utility method
