### PR TITLE
Added facilities for the travis build, currently Linux only.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: go
+
+go:
+  - 1.4.1
+
+os:
+  - linux
+  - osx
+
+install:
+  - go get -t -v ./...
+  - sudo apt-get install -qq libfuse-dev pkg-config fuse user-mode-linux slirp
+  - sudo mknod /dev/fuse c 10 229
+  - sudo chmod 666 /dev/fuse
+
+script: bin/umltest.sh

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ Suffuse client
 
 A raw snapshot of generic file virtualization in progress. Written in go.
 
+|OS    |Status|
+|------|------|
+|Linux |[![Build Status](https://travis-ci.org/suffuse/go-suffuse.svg?branch=master)](https://travis-ci.org/suffuse/go-suffuse)|
+
+
 Prerequisites
 =============
 

--- a/bin/umltest.sh
+++ b/bin/umltest.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# We need the following inside User Mode Linux
+CURDIR="`pwd`"
+GOPATH="$GOPATH"
+GOROOT="$GOROOT"
+PATH="$PATH"
+
+cat > umltest.inner.sh <<EOF
+#!/bin/sh
+(
+   set -e
+   set -x
+
+   # Enable fuse
+   insmod /usr/lib/uml/modules/\`uname -r\`/kernel/fs/fuse/fuse.ko
+
+   # Navigate to the current directory
+   cd "$CURDIR"
+
+   # Mount the processes of the external environment
+   mount -t proc proc /proc
+
+   # Enable the network
+   ifconfig lo up; ifconfig eth0 10.0.2.15; ip route add default via 10.0.2.1
+
+   # Make sure we live in the same environment
+   export GOPATH="$GOPATH"
+   export GOROOT="$GOROOT"
+   export PATH="$PATH"
+
+   # List Go version and environment
+   go version
+   go env
+
+   # Run tests
+   go test -v ./...
+
+   echo Success
+)
+echo "\$?" > "$CURDIR"/umltest.status
+halt -f
+EOF
+
+chmod +x umltest.inner.sh
+
+# Execute the script in user mode linux
+/usr/bin/linux.uml init=`pwd`/umltest.inner.sh eth0=slirp rootfstype=hostfs mem=256M rw
+
+exit $(<umltest.status)


### PR DESCRIPTION
Fuse can only be run inside User Mode Linux, details for running it are found in `bin/umltest.sh`

Used information from:
- https://github.com/go-fsnotify/fsnotify
- https://github.com/vi/execfuse
- http://stackoverflow.com/questions/23937413/continuous-delivery-for-fuse-oss-and-github/28070347#28070347
