### PR TITLE
Improved separation of concerns for `SfsOpts`

### DIFF
--- a/cmd/suffuse/main.go
+++ b/cmd/suffuse/main.go
@@ -1,11 +1,18 @@
 package main
 
-import . "github.com/suffuse/go-suffuse/suffuse"
+import (
+  . "github.com/suffuse/go-suffuse/suffuse"
+  "os"
+)
 
 func main() {
-  opts := ParseSfsOpts()
+  conf, conf_err := CreateSfsConfig(os.Args)
+  if conf_err != nil {
+    conf_err.PrintUsage()
+    os.Exit(2)
+  }
 
-  mfs, err := opts.Create()
+  mfs, err := NewSfs(conf)
   MaybePanic(err)
 
   err = mfs.Serve()

--- a/suffuse/log.go
+++ b/suffuse/log.go
@@ -22,10 +22,3 @@ func level(max lg.Lvl) lg.Logger {
 }
 
 func SetLogLevel(max lg.Lvl) { sfsLogger = level(max) }
-func (opts SfsOpts) GetLogLevel() lg.Lvl {
-  switch {
-    case opts.Debug   : return lg.LvlDebug
-    case opts.Verbose : return lg.LvlInfo
-    default           : return lg.LvlWarn
-  }
-}

--- a/suffuse/path.go
+++ b/suffuse/path.go
@@ -14,6 +14,9 @@ type Path struct {
 func NewPath(path string) Path {
   return Path { path }
 }
+func NewPathRef(path string) *Path {
+  if path == "" { return nil } else { return &Path{ path } }
+}
 func NewPaths(paths ...string) []Path {
   xs := make([]Path, len(paths))
   for i, p := range paths { xs[i] = NewPath(p) }
@@ -182,4 +185,10 @@ func (x Path) WalkCollect(f func(string, os.FileInfo) string) Lines {
     },
   )
   return NewLines(res...)
+}
+
+// https://github.com/golang/go/issues/1312
+func (x Path) FileExists() bool {
+  _, err := x.OsStat()
+  return err == nil
 }

--- a/suffuse/setup_test.go
+++ b/suffuse/setup_test.go
@@ -1,7 +1,6 @@
 package suffuse
 
 import (
-  "os"
   "testing"
   "strings"
   "runtime"
@@ -48,12 +47,10 @@ seq 1 10000 > bigfile.txt
 }
 
 func startFuse(args ...string) {
-  saved := os.Args
-  os.Args = args
-  opts := ParseSfsOpts()
-  os.Args = saved
+  conf, conf_err := CreateSfsConfig(args)
+  if conf_err != nil { return }
 
-  mfs, err := opts.Create()
+  mfs, err := NewSfs(conf)
   MaybePanic(err)
 
   go func() {

--- a/suffuse/sfs.go
+++ b/suffuse/sfs.go
@@ -4,6 +4,7 @@ import (
   "golang.org/x/net/context"
   "bazil.org/fuse/fs"
   "bazil.org/fuse"
+  "os"
 )
 
 /** Sfs == Suffuse File System.
@@ -25,6 +26,50 @@ type Sfs struct {
 // call fs.Serve to serve the FUSE protocol using an implementation of
 // the service methods in the interfaces FS* (file system), Node* (file
 // or directory), and Handle* (opened file or directory).
+
+func NewSfs(conf *SfsConfig) (*Sfs, error) {
+  SetLogLevel(conf.LogLevel)
+         mnt := conf.Mountpoint
+  mount_opts := getFuseMountOptions(conf)
+
+  if conf.Config != nil {
+    configFileOpts := ReadJsonFile(*conf.Config)
+    Echoerr("%v", configFileOpts)
+  }
+
+  c, err := fuse.Mount(mnt.Path, mount_opts...)
+  if err != nil { return nil, err }
+
+  mfs := &Sfs {
+    Mountpoint : mnt,
+    RootNode   : NewIdNode(conf.Paths[0]),
+    Connection : c,
+  }
+
+  /** Start a goroutine which looks for INT/TERM and
+   *  calls unmount on the filesystem. Otherwise ctrl-C
+   *  leaves us with ghost mounts which outlive the process.
+   */
+  trap := func (sig os.Signal) {
+    Echoerr("Caught %s - forcing unmount(2) of %s\n", sig, mfs.Mountpoint)
+    mfs.Unmount()
+  }
+  TrapExit(trap)
+  return mfs, nil
+}
+
+func getFuseMountOptions(conf *SfsConfig) []fuse.MountOption {
+  mount_opts := []fuse.MountOption { fuse.FSName("suffuse") }
+  mount_opts = append(mount_opts, PlatformOptions()...)
+  if conf.VolName != "" {
+    mount_opts = append(mount_opts,
+      fuse.LocalVolume(),
+      fuse.VolumeName(conf.VolName),
+    )
+  }
+  return mount_opts
+}
+
 func (u *Sfs) Root() (fs.Node, error) { return u.RootNode, nil }
 
 func (u *Sfs) Init(ctx context.Context, req *fuse.InitRequest, resp *fuse.InitResponse) error {


### PR DESCRIPTION
- Moved the responsibility of reporting errors outside of `SfsOpts`
- Renamed `Args` to `Paths` which reflects intention a bit better
- `ParseSfsOpts` now takes an array of strings and returns (potentially) an error
- Improved general error reporting for the creation of options (options are validated)
- Moved the creation of a `Sfs` to `sfs.go`
- Added a `FileExists` utility method
