### PR TITLE
Removing, moving and privatizing

### DIFF
--- a/suffuse/config.go
+++ b/suffuse/config.go
@@ -4,29 +4,29 @@ import (
   "encoding/json"
 )
 
-var RuleFactories = map[string]func() Rule {
+var ruleFactories = map[string]func() Rule {
   "file_command"   : func() Rule { return &FileCommand{}    },
   "file_conversion": func() Rule { return &FileConversion{} },
 }
 
-type ConfigEntry struct {
+type configEntry struct {
   Nature string
   Config json.RawMessage
 }
 
 func CreateRules(config []byte) ([]Rule, error) {
-  var entries []ConfigEntry
+  var entries []configEntry
   err := json.Unmarshal(config, &entries)
   if err != nil { return nil, err }
 
   return entriesToRules(entries)
 }
 
-func entriesToRules(entries []ConfigEntry) ([]Rule, error) {
+func entriesToRules(entries []configEntry) ([]Rule, error) {
   results := make([]Rule, len(entries))
 
   for i, entry := range entries {
-    val := RuleFactories[entry.Nature]()
+    val := ruleFactories[entry.Nature]()
     err := json.Unmarshal(entry.Config, val)
     if err != nil { return nil, err }
     results[i] = val

--- a/suffuse/examples_test.go
+++ b/suffuse/examples_test.go
@@ -128,7 +128,7 @@ func echo(s string) string {
 }
 
 func installConverterFunctions() {
-  execute(string(Cwd()))(`
+  execute(string(cwd()))(`
     go get github.com/dbohdan/remarshal
 
     for if in toml yaml json; do

--- a/suffuse/idnode.go
+++ b/suffuse/idnode.go
@@ -16,6 +16,8 @@ type IdNode struct {
   Path Path
 }
 
+var NoNode = NewIdNode(NoPath)
+
 func NewIdNode(path Path) *IdNode {
   return &IdNode { Path: path }
 }
@@ -121,7 +123,7 @@ func (x *IdNode) Setattr(ctx context.Context, req *f.SetattrRequest, resp *f.Set
 func (x *IdNode) Attr(ctx context.Context, attr *f.Attr) error {
   logD("Attr", "path", x.Path)
 
-  for _, rule := range Rules {
+  for _, rule := range rules {
     a := rule.MetaData(x.Path)
     if a != nil {
       *attr = *a
@@ -149,7 +151,7 @@ func (x *IdNode) Lookup(ctx context.Context, name string) (fs.Node, error) {
 func (x *IdNode) ReadDirAll(ctx context.Context) ([]f.Dirent, error) {
   logD("ReadDirAll", "path", x.Path)
 
-  for _, rule := range Rules {
+  for _, rule := range rules {
     children := rule.DirData(x.Path)
     if children != nil { return children, nil }
   }
@@ -159,7 +161,7 @@ func (x *IdNode) Readlink(ctx context.Context, req *f.ReadlinkRequest) (string, 
   path := x.Path
   logD("Readlink", "path", path)
 
-  for _, rule := range Rules {
+  for _, rule := range rules {
     target := rule.LinkData(path)
     if target != nil { return string(*target), nil }
   }
@@ -169,7 +171,7 @@ func (x *IdNode) Read(ctx context.Context, req *f.ReadRequest, resp *f.ReadRespo
   path := x.Path
   logD("Read", "path", path, "req", *req)
 
-  for _, rule := range Rules {
+  for _, rule := range rules {
     bytes := rule.FileData(path)
     if bytes != nil {
       HandleRead(req, resp, bytes)
@@ -182,7 +184,7 @@ func (x *IdNode) ReadAll(ctx context.Context) ([]byte, error) {
   path := x.Path
   logD("ReadAll", "path", path)
 
-  for _, rule := range Rules {
+  for _, rule := range rules {
     bytes := rule.FileData(path)
     if bytes != nil {
       return bytes, nil

--- a/suffuse/json.go
+++ b/suffuse/json.go
@@ -2,10 +2,9 @@ package suffuse
 
 import (
   "encoding/json"
-  "io/ioutil"
 )
 
-func ReadJsonFile(p Path) map[string]interface{} {
+func readJsonFile(p Path) map[string]interface{} {
   bs  := p.SlurpBytes()
   var f map[string]interface{}
   json.Unmarshal(bs, &f)
@@ -13,13 +12,6 @@ func ReadJsonFile(p Path) map[string]interface{} {
   return f
 }
 
-func WriteJsonFile(p Path, x interface{}) {
-  data, err := json.Marshal(x)
-  if err == nil {
-    ioutil.WriteFile(string(p), data, 0444)
-  }
-}
-
 func JsonPretty(x interface{}) string {
-  return MaybeByteString(json.MarshalIndent(x, "", "    "))
+  return maybeByteString(json.MarshalIndent(x, "", "    "))
 }

--- a/suffuse/lines.go
+++ b/suffuse/lines.go
@@ -4,20 +4,40 @@ package suffuse
  */
 
 import (
-  "regexp"
   "strings"
 )
 
-/** Without generics and with barely usable HOFs we're in hell.
- *  Here we focus on Lines as a collection of Strings and reimplement
- *  swaths of better languages in terms of exactly 1/Nth of the
- *  types of interest.
- */
-type Regex struct {
-  *regexp.Regexp
-}
 type Lines struct {
   Strings []string
+}
+
+func NewLines(lines ...string) Lines { return Lines { lines } }
+
+func BytesToLines(bytes []byte) Lines {
+  return SplitLines(strings.TrimSpace(string(bytes)))
+}
+
+func (x Lines) Join(sep string) string   { return strings.Join(x.Strings, sep) }
+func (x Lines) JoinWords() string        { return x.TrimAll().Join(" ")        }
+func (x Lines) Len() int                 { return len(x.Strings)               }
+func (x Lines) String() string           { return x.Join("\n")                 }
+
+func (x Lines) TrimAll() Lines { return x.Map(func(s string)string { return strings.TrimSpace(s) }) }
+
+func (x Lines) Map(f func(string)string) Lines {
+  res := make([]string, x.Len())
+  for i, x := range x.Strings { res[i] = f(x) }
+  return NewLines(res...)
+}
+func (x Lines) FlatMap(f func(string)[]string) Lines {
+  res := make([]string, 0)
+  for _, x := range x.Strings { res = append(res, f(x)...) }
+  return NewLines(res...)
+}
+func (x Lines) Fold(f func(string, string)string) string {
+  res := ""
+  for _, x := range x.Strings { res = f(res, x) }
+  return res
 }
 
 // TODO - strings methods to expose on a more convenient String type
@@ -35,57 +55,7 @@ type Lines struct {
 // TrimPrefix(s, prefix string) string
 // TrimSuffix(s, suffix string) string
 
-func NewLines(lines ...string) Lines { return Lines { lines                  } }
-func NewRegex(re string) Regex       { return Regex { regexp.MustCompile(re) } }
-
-func SplitLines(s string) Lines     { return NewLines(strings.Split(s, "\n")...) }
-func Strings(xs ...string) []string { return xs                                  }
-func ByteBuf(size int) []byte       { return make([]byte, size)                  }
-
-func (x Lines) Filter(re Regex) Lines    { return filterCommon(x, re, true)    }
-func (x Lines) FilterNot(re Regex) Lines { return filterCommon(x, re, false)   }
-func (x Lines) IsEmpty() bool            { return x.Len() == 0                 }
-func (x Lines) Join(sep string) string   { return strings.Join(x.Strings, sep) }
-func (x Lines) JoinWords() string        { return x.TrimAll().Join(" ")        }
-func (x Lines) Len() int                 { return len(x.Strings)               }
-func (x Lines) String() string           { return x.Join("\n")                 }
-
-func (x Lines) TrimAll() Lines { return x.Map(func(s string)string { return strings.TrimSpace(s) }) }
-
-func filterCommon(x Lines, re Regex, expectTrue bool) Lines {
-  xs := x.Strings
-  ys := make([]string, 0)
-
-  for _, line := range xs {
-    if re.MatchString(line) == expectTrue {
-      ys = append(ys, line)
-    }
-  }
-  return NewLines(ys...)
-}
-func (x Lines) Map(f func(string)string) Lines {
-  res := make([]string, x.Len())
-  for i, x := range x.Strings { res[i] = f(x) }
-  return NewLines(res...)
-}
-func (x Lines) MapIndex(f func(int, string)string) Lines {
-  res := make([]string, x.Len())
-  for i, x := range x.Strings { res[i] = f(i, x) }
-  return NewLines(res...)
-}
-func (x Lines) FlatMap(f func(string)[]string) Lines {
-  res := make([]string, 0)
-  for _, x := range x.Strings { res = append(res, f(x)...) }
-  return NewLines(res...)
-}
-func (x Lines) Fold(f func(string, string)string) string {
-  res := ""
-  for _, x := range x.Strings { res = f(res, x) }
-  return res
-}
-func BytesToLines(bytes []byte) Lines {
-  return SplitLines(strings.TrimSpace(string(bytes)))
-}
+func SplitLines(s string) Lines { return NewLines(strings.Split(s, "\n")...) }
 
 /** String manipulation, should go on a string type but doesn't yet.
  */

--- a/suffuse/lines_test.go
+++ b/suffuse/lines_test.go
@@ -23,7 +23,7 @@ func (s *Tsfs) TestStripMargin(c *C) {
 func (s *Tsfs) TestLines(c *C) {
     ls := NewLines("dog  ", "  cat", " monkey in middle ")
    one := ls.JoinWords()
-    fm := ls.FlatMap(func(s string)[]string { return Strings("a", "b") }).JoinWords()
+    fm := ls.FlatMap(func(s string)[]string { return []string{"a", "b"} }).JoinWords()
   fold := ls.Fold(func(acc, s string)string { return fmt.Sprintf("%s%d!", acc, len(s)) })
 
   c.Assert(one, Equals, "dog cat monkey in middle")

--- a/suffuse/path_test.go
+++ b/suffuse/path_test.go
@@ -5,6 +5,8 @@ import (
   . "gopkg.in/check.v1"
 )
 
+var dotPath = Path(".")
+
 func NewDuration(spec string) time.Duration {
   dur, err := time.ParseDuration(spec)
   MaybePanic(err)
@@ -50,11 +52,11 @@ func (s *Tsfs) TestPathSymlinkLogic(c *C) {
 
   // Create symlink "link3" -> ".", where "." is now $d.
   link3 := Path("link3")
-  link3.OsSymlink(DotPath)
+  link3.OsSymlink(dotPath)
 
   // Ensure that $d, $(pwd), and "." all resolve to the same path.
-  c.Assert(d, Equals, CwdNoLinks())
-  c.Assert(d, Equals, DotPath.Absolute())
+  c.Assert(d, Equals, cwd())
+  c.Assert(d, Equals, dotPath.Absolute())
 
   // Ensure that link1, link2, and link3 all resolve to the same path.
   AssertSameFile(c, link1, link2)

--- a/suffuse/process.go
+++ b/suffuse/process.go
@@ -1,28 +1,14 @@
 package suffuse
 
 import (
+  "os"
   "os/exec"
-  "github.com/shirou/gopsutil/process"
   "github.com/shirou/gopsutil/host"
 )
 
-func PsutilHostDump () {
+func psutilHostDump () {
   hostInfo, _ := host.HostInfo()
   Println(JsonPretty(*hostInfo))
-  // Printfln("%#v", ProcessTable())
-}
-
-func ProcessTable() map[int32]string {
-  res := make(map[int32]string)
-  pids, _ := process.Pids()
-
-  for i := 0 ; i < len(pids) ; i++ {
-    pid := pids[i]
-    proc, _ := process.NewProcess(pid)
-    cline, _ := proc.Cmdline()
-    res[pid] = cline
-  }
-  return res
 }
 
 type ExecResult struct {
@@ -30,13 +16,15 @@ type ExecResult struct {
   Stdout []byte
 }
 
+func cwd() Path        { return MaybePath(os.Getwd()) }
+
 func (x ExecResult) OneLine() string { return x.Lines().JoinWords()  }
 func (x ExecResult) Lines() Lines    { return BytesToLines(x.Stdout) }
 func (x ExecResult) Slurp() string   { return string(x.Stdout)       }
 func (x ExecResult) Success() bool   { return x.Err == nil           }
 
-func Exec(args ...string) ExecResult                { return ExecIn(Cwd(), args...)            }
-func ExecBash(script string) ExecResult             { return ExecBashIn(Cwd(), script)         }
+func Exec(args ...string) ExecResult                { return ExecIn(cwd(), args...)            }
+func ExecBash(script string) ExecResult             { return ExecBashIn(cwd(), script)         }
 func ExecBashIn(cwd Path, script string) ExecResult { return ExecIn(cwd, "bash", "-c", script) }
 
 func ExecIn(cwd Path, args ...string) ExecResult {

--- a/suffuse/sfs.go
+++ b/suffuse/sfs.go
@@ -1,7 +1,6 @@
 package suffuse
 
 import (
-  "golang.org/x/net/context"
   "bazil.org/fuse/fs"
   "bazil.org/fuse"
   "os"
@@ -33,7 +32,7 @@ func NewSfs(conf *SfsConfig) (*Sfs, error) {
   mount_opts := getFuseMountOptions(conf)
 
   if !conf.Config.IsEmpty() {
-    configFileOpts := ReadJsonFile(conf.Config)
+    configFileOpts := readJsonFile(conf.Config)
     Echoerr("%v", configFileOpts)
   }
 
@@ -71,23 +70,6 @@ func getFuseMountOptions(conf *SfsConfig) []fuse.MountOption {
 }
 
 func (u *Sfs) Root() (fs.Node, error) { return u.RootNode, nil }
-
-func (u *Sfs) Init(ctx context.Context, req *fuse.InitRequest, resp *fuse.InitResponse) error {
-  logI("Init", "req", req)
-  return nil
-}
-
-func (u *Sfs) Destroy(ctx context.Context) {
-  logI("Destroy")
-}
-
-func (u *Sfs) Statfs(ctx context.Context, req *fuse.StatfsRequest, resp *fuse.StatfsResponse) error {
-  logD("Statfs")
-  stat, err := RootPath.SysStatfs()
-  if err != nil { return err }
-  *resp = SysStatfsToFuseStatfs(stat)
-  return nil
-}
 
 func (u *Sfs) Unmount() error {
   return u.Mountpoint.SysUnmount()

--- a/suffuse/suffuse.go
+++ b/suffuse/suffuse.go
@@ -5,20 +5,18 @@ import (
 )
 
 const (
-  SfsConfigFileName = ".sfs"
-  DefaultFilePerms  = os.FileMode(0644)
-  DefaultDirPerms   = os.FileMode(0755)
+  defaultFilePerms  = os.FileMode(0644)
 )
 
 /** Eventually we'll read this kind of information out of a config
  *  file, but for now it's hardcoded here.
  */
-var Rules = append(
+var rules = append(
   []Rule { &IdRule{} },  // The identity fs - passes underlying paths through unchanged
-  rules()...
+  parseRules()...
 )
 
-func rules() []Rule {
+func parseRules() []Rule {
   conf := []byte(`[
     {
       "nature" : "file_command",
@@ -44,13 +42,3 @@ func rules() []Rule {
 
   return rules
 }
-
-var NoNode = NewIdNode(NoPath)
-
-var NoPath     = Path("")
-var RootPath   = Path("/")
-var DotPath    = Path(".")
-var DotDotPath = Path("..")
-
-// TODO - actually delete on exit.
-var deleteOnExit = make([]Path, 0)

--- a/suffuse/util.go
+++ b/suffuse/util.go
@@ -35,6 +35,9 @@ func FindError(errors ...error) error {
 
 func NewErr(text string) error { return errors.New(text) }
 
+// TODO - actually delete on exit.
+var deleteOnExit = make([]Path, 0)
+
 func ScratchDir() Path {
   dir, err := ioutil.TempDir("", "suffuse")
   MaybeFatal(err)
@@ -48,4 +51,9 @@ func ScratchFile() Path {
   path := Path(fh.Name())
   deleteOnExit = append(deleteOnExit, path)
   return path
+}
+
+func maybeByteString(result []byte, err error) string {
+  if err != nil { return "" }
+  return string(result)
 }


### PR DESCRIPTION
- Renamed some of the internal config members to private
- Moved `cwd` to process
- Moved NoXXX next to the constructors
- Removed some unused code
- Moved regex methods to the test that used them
- Moved the string methods to the bottom of the lines file for now
- Removed unused lines methods
- Removed unused constants

Let me know which ones you like and which ones you do not like.
