### PR TITLE
Range type.

### DIFF
--- a/suffuse/bytes.go
+++ b/suffuse/bytes.go
@@ -1,0 +1,24 @@
+package suffuse
+
+/** In any other language we could generically leverage the operations
+ *  on Range and apply them to Bytes. Ha ha.
+ */
+
+type Bytes []byte
+
+var NoBytes = Bytes([]byte {})
+
+func (bs Bytes) ToRange()Range {
+  return RangeOffsetLength(0, len(bs))
+}
+func (bs Bytes) SliceRange(slice Range)Bytes {
+  r := bs.ToRange().SliceRange(slice)
+  if r.IsEmpty() {
+    return NoBytes
+  } else {
+    return bs[r.StartInt():r.EndInt()]
+  }
+}
+func (bs Bytes) Slice(start, end int)Bytes {
+  return bs.SliceRange(RangeStartEnd(start, end))
+}

--- a/suffuse/bytes.go
+++ b/suffuse/bytes.go
@@ -8,10 +8,10 @@ type Bytes []byte
 
 var NoBytes = Bytes([]byte {})
 
-func (bs Bytes) ToRange()Range {
+func (bs Bytes) ToRange() Range {
   return RangeOffsetLength(0, len(bs))
 }
-func (bs Bytes) SliceRange(slice Range)Bytes {
+func (bs Bytes) SliceRange(slice Range) Bytes {
   r := bs.ToRange().SliceRange(slice)
   if r.IsEmpty() {
     return NoBytes
@@ -19,6 +19,6 @@ func (bs Bytes) SliceRange(slice Range)Bytes {
     return bs[r.StartInt():r.EndInt()]
   }
 }
-func (bs Bytes) Slice(start, end int)Bytes {
+func (bs Bytes) Slice(start, end int) Bytes {
   return bs.SliceRange(RangeStartEnd(start, end))
 }

--- a/suffuse/bytes_test.go
+++ b/suffuse/bytes_test.go
@@ -1,0 +1,24 @@
+package suffuse
+
+import (
+  . "gopkg.in/check.v1"
+)
+
+func (s *Tsfs) TestBytesSliceRange(c *C) {
+  // byte slices.
+  bs := Bytes([]byte("0123456789"))
+  s1 := RangeOffsetLength(4, 6)
+  s2 := RangeOffsetLength(0, 4)
+  s3 := s1.SliceRange(s2)
+  s4 := s2.SliceRange(s1)
+
+  AssertString(c, string(bs.SliceRange(s1)), "456789")
+  AssertString(c, string(bs.SliceRange(s2)), "0123")
+  AssertString(c, string(bs.SliceRange(s3)), "4567")
+  AssertString(c, string(bs.SliceRange(s4)), "")
+
+  AssertString(c, string(bs.SliceRange(s1).SliceRange(s2)), "4567")
+  AssertString(c, string(bs.SliceRange(s2).SliceRange(s1)), "")
+  AssertString(c, string(bs.SliceRange(s1).Slice(0, 4)), "4567")
+  AssertString(c, string(bs.SliceRange(s2).Slice(4, 6)), "")
+}

--- a/suffuse/range.go
+++ b/suffuse/range.go
@@ -1,0 +1,79 @@
+package suffuse
+
+/** Go slices fail hard if the inputs don't make sense, but
+ *  slices are much more convenient to work with if they do the
+ *  sensible thing when you overshoot, e.g. slice[0:10] if there
+ *  are only 5 elements would give you the 5. Range superimposes
+ *  the scala-like forgiving slice logic on top of native slices.
+ */
+type Offset uint
+type Length uint
+
+type Range struct {
+  Offset
+  Length
+}
+
+/** All empty ranges are defined as 0:0. We don't want the
+ *  start value of an empty range to be considered meaningful
+ *  or stable under any operations.
+ */
+var EmptyRange Range = Range { Offset(0), Length(0) }
+
+func (x Range) IsEmpty()bool  { return x.LengthInt() == 0           }
+func (x Range) StartInt()int  { return int(x.Offset)                }
+func (x Range) EndInt()int    { return x.StartInt() + x.LengthInt() }
+func (x Range) LengthInt()int { return int(x.Length)                }
+
+func (x Range) String()string {
+  if x.IsEmpty() {
+    return "0:0"
+  } else {
+    return Sprintf("%v:%v", x.StartInt(), x.LengthInt())
+  }
+}
+func min(x int, y int)int {
+  if x <= y { return x }
+  return y
+}
+
+func RangeOffsetLength(offset int, length int)Range {
+  if offset < 0 {
+    return RangeOffsetLength(0, length)
+  } else if length <= 0 {
+    return EmptyRange
+  } else {
+    return Range { Offset(offset), Length(length) }
+  }
+}
+func RangeStartEnd(start int, end int)Range {
+  if start < 0 {
+    return RangeStartEnd(0, end)
+  } else if end <= start || end <= 0 {
+    return EmptyRange
+  } else {
+    return RangeOffsetLength(start, end - start)
+  }
+}
+func (x Range) Drop(n int)Range {
+  if n <= 0 { return x }
+  return RangeStartEnd(x.StartInt() + n, x.EndInt())
+}
+func (x Range) DropRight(n int)Range {
+  if n <= 0 { return x }
+  return RangeStartEnd(x.StartInt(), x.EndInt() - n)
+}
+func (x Range) Take(n int)Range {
+  length := min(n, x.LengthInt())
+  return RangeOffsetLength(x.StartInt(), length)
+}
+func (x Range) TakeRight(n int)Range {
+  length := min(n, x.LengthInt())
+  return RangeOffsetLength(x.EndInt() - length, length)
+}
+func (x Range) SliceRange(r Range)Range {
+  return x.Drop(r.StartInt()).Take(r.LengthInt())
+}
+func (x Range) Slice(start, end int)Range {
+  return x.SliceRange(RangeStartEnd(start, end))
+}

--- a/suffuse/range.go
+++ b/suffuse/range.go
@@ -20,24 +20,20 @@ type Range struct {
  */
 var EmptyRange Range = Range { Offset(0), Length(0) }
 
-func (x Range) IsEmpty()bool  { return x.LengthInt() == 0           }
-func (x Range) StartInt()int  { return int(x.Offset)                }
-func (x Range) EndInt()int    { return x.StartInt() + x.LengthInt() }
-func (x Range) LengthInt()int { return int(x.Length)                }
+func (x Range) IsEmpty() bool  { return x.LengthInt() == 0           }
+func (x Range) StartInt() int  { return int(x.Offset)                }
+func (x Range) EndInt() int    { return x.StartInt() + x.LengthInt() }
+func (x Range) LengthInt() int { return int(x.Length)                }
 
-func (x Range) String()string {
+func (x Range) String() string {
   if x.IsEmpty() {
     return "0:0"
   } else {
     return Sprintf("%v:%v", x.StartInt(), x.LengthInt())
   }
 }
-func min(x int, y int)int {
-  if x <= y { return x }
-  return y
-}
 
-func RangeOffsetLength(offset int, length int)Range {
+func RangeOffsetLength(offset int, length int) Range {
   if offset < 0 {
     return RangeOffsetLength(0, length)
   } else if length <= 0 {
@@ -46,7 +42,7 @@ func RangeOffsetLength(offset int, length int)Range {
     return Range { Offset(offset), Length(length) }
   }
 }
-func RangeStartEnd(start int, end int)Range {
+func RangeStartEnd(start int, end int) Range {
   if start < 0 {
     return RangeStartEnd(0, end)
   } else if end <= start || end <= 0 {
@@ -55,25 +51,32 @@ func RangeStartEnd(start int, end int)Range {
     return RangeOffsetLength(start, end - start)
   }
 }
-func (x Range) Drop(n int)Range {
+
+func (x Range) Drop(n int) Range {
   if n <= 0 { return x }
   return RangeStartEnd(x.StartInt() + n, x.EndInt())
 }
-func (x Range) DropRight(n int)Range {
+func (x Range) DropRight(n int) Range {
   if n <= 0 { return x }
   return RangeStartEnd(x.StartInt(), x.EndInt() - n)
 }
-func (x Range) Take(n int)Range {
+func (x Range) Take(n int) Range {
   length := min(n, x.LengthInt())
   return RangeOffsetLength(x.StartInt(), length)
 }
-func (x Range) TakeRight(n int)Range {
+func (x Range) TakeRight(n int) Range {
   length := min(n, x.LengthInt())
   return RangeOffsetLength(x.EndInt() - length, length)
 }
-func (x Range) SliceRange(r Range)Range {
+
+func (x Range) SliceRange(r Range) Range {
   return x.Drop(r.StartInt()).Take(r.LengthInt())
 }
-func (x Range) Slice(start, end int)Range {
+func (x Range) Slice(start, end int) Range {
   return x.SliceRange(RangeStartEnd(start, end))
+}
+
+func min(x int, y int) int {
+  if x <= y { return x }
+  return y
 }

--- a/suffuse/range_test.go
+++ b/suffuse/range_test.go
@@ -58,20 +58,4 @@ func (s *Tsfs) TestRange(c *C) {
   AssertString(c, r.Slice(-2, -1), "0:0")
   AssertString(c, r.Slice(-2, 2), "1:2")
 
-  // byte slices.
-  bs := Bytes([]byte("0123456789"))
-  s1 := RangeOffsetLength(4, 6)
-  s2 := RangeOffsetLength(0, 4)
-  s3 := s1.SliceRange(s2)
-  s4 := s2.SliceRange(s1)
-
-  AssertString(c, string(bs.SliceRange(s1)), "456789")
-  AssertString(c, string(bs.SliceRange(s2)), "0123")
-  AssertString(c, string(bs.SliceRange(s3)), "4567")
-  AssertString(c, string(bs.SliceRange(s4)), "")
-
-  AssertString(c, string(bs.SliceRange(s1).SliceRange(s2)), "4567")
-  AssertString(c, string(bs.SliceRange(s2).SliceRange(s1)), "")
-  AssertString(c, string(bs.SliceRange(s1).Slice(0, 4)), "4567")
-  AssertString(c, string(bs.SliceRange(s2).Slice(4, 6)), "")
 }

--- a/suffuse/range_test.go
+++ b/suffuse/range_test.go
@@ -1,0 +1,77 @@
+package suffuse
+
+import (
+  . "gopkg.in/check.v1"
+)
+
+// Brute force testing all the obvious boundary conditions.
+// Ranges are printed as <start>:<length>
+// All empty ranges are 0:0 so <start> cannot accidentally
+// be treated as meaningful on a zero length range.
+func (s *Tsfs) TestRange(c *C) {
+  r := RangeStartEnd(1, 5) // [ 1, 2, 3, 4 ]
+  AssertString(c, r, "1:4")
+
+  // negative arg
+  AssertString(c, r.Drop(-1), "1:4")
+  AssertString(c, r.DropRight(-1), "1:4")
+  AssertString(c, r.Take(-1), "0:0")
+  AssertString(c, r.TakeRight(-1), "0:0")
+
+  // zero arg
+  AssertString(c, r.Drop(0), "1:4")
+  AssertString(c, r.DropRight(0), "1:4")
+  AssertString(c, r.Take(0), "0:0")
+  AssertString(c, r.TakeRight(0), "0:0")
+
+  // positive arg
+  AssertString(c, r.Drop(1), "2:3")
+  AssertString(c, r.DropRight(1), "1:3")
+  AssertString(c, r.Take(1), "1:1")
+  AssertString(c, r.TakeRight(1), "4:1")
+
+  // length - 1
+  AssertString(c, r.Drop(3), "4:1")
+  AssertString(c, r.DropRight(3), "1:1")
+  AssertString(c, r.Take(3), "1:3")
+  AssertString(c, r.TakeRight(3), "2:3")
+
+  // length
+  AssertString(c, r.Drop(4), "0:0")
+  AssertString(c, r.DropRight(4), "0:0")
+  AssertString(c, r.Take(4), "1:4")
+  AssertString(c, r.TakeRight(4), "1:4")
+
+  // length + 1
+  AssertString(c, r.Drop(5), "0:0")
+  AssertString(c, r.DropRight(5), "0:0")
+  AssertString(c, r.Take(5), "1:4")
+  AssertString(c, r.TakeRight(5), "1:4")
+
+  // slice is implemented in terms of take and drop so is
+  // primarily assured by the above passing.
+  AssertString(c, r.Slice(0, 0), "0:0")
+  AssertString(c, r.Slice(0, 1), "1:1")
+  AssertString(c, r.Slice(0, 2), "1:2")
+  AssertString(c, r.Slice(1, 2), "2:1")
+  AssertString(c, r.Slice(2, 1), "0:0")
+  AssertString(c, r.Slice(-2, -1), "0:0")
+  AssertString(c, r.Slice(-2, 2), "1:2")
+
+  // byte slices.
+  bs := Bytes([]byte("0123456789"))
+  s1 := RangeOffsetLength(4, 6)
+  s2 := RangeOffsetLength(0, 4)
+  s3 := s1.SliceRange(s2)
+  s4 := s2.SliceRange(s1)
+
+  AssertString(c, string(bs.SliceRange(s1)), "456789")
+  AssertString(c, string(bs.SliceRange(s2)), "0123")
+  AssertString(c, string(bs.SliceRange(s3)), "4567")
+  AssertString(c, string(bs.SliceRange(s4)), "")
+
+  AssertString(c, string(bs.SliceRange(s1).SliceRange(s2)), "4567")
+  AssertString(c, string(bs.SliceRange(s2).SliceRange(s1)), "")
+  AssertString(c, string(bs.SliceRange(s1).Slice(0, 4)), "4567")
+  AssertString(c, string(bs.SliceRange(s2).Slice(4, 6)), "")
+}

--- a/suffuse/setup_test.go
+++ b/suffuse/setup_test.go
@@ -1,6 +1,7 @@
 package suffuse
 
 import (
+  "fmt"
   "testing"
   "strings"
   "runtime"
@@ -78,6 +79,16 @@ func AssertExecSuccess(c *C, args ...string) {
 }
 func AssertSameFile(c *C, p1, p2 Path) {
   c.Assert(p1.EvalSymlinks(), Equals, p2.EvalSymlinks())
+}
+// "found fmt.Stringer" means you can't pass a string. Oyve.
+func AssertString(c *C, found interface{}, expected string) {
+  var str string
+  switch found := found.(type) {
+    case fmt.Stringer : str = found.String()
+    case string       : str = found
+    default           : panic(Sprintf("Unexpected type %T", found))
+  }
+  c.Assert(str, Equals, expected)
 }
 
 func (s *Tsfs) SetUpSuite(c *C) {


### PR DESCRIPTION
Go slices fail hard if the inputs don't make sense, but
slices are much more convenient to work with if they do the
sensible thing when you overshoot, e.g. slice[0:10] if there
are only 5 elements would give you the 5. Range superimposes
the scala-like forgiving slice logic on top of native slices.
